### PR TITLE
Update groups on message receive. Also ignore scene messages for now

### DIFF
--- a/nodes/server.js
+++ b/nodes/server.js
@@ -215,12 +215,8 @@ module.exports = function(RED) {
             if (dataParsed.r == "groups") {
                var groupid = dataParsed.id;
                var state = dataParsed.state
-               for (var group in this.groups) {
-                   if ( group[groupid] && group[groupid] == groupid ) {
-                       this.groups[groupid].state = state;
-                       return;
-                   }
-               }
+               this.groups[groupid].state = state;
+               return;
             }
             for (var nodeId in this.devices) {
                 var item = this.devices[nodeId];

--- a/nodes/server.js
+++ b/nodes/server.js
@@ -211,6 +211,17 @@ module.exports = function(RED) {
         }
 
         onSocketMessage(dataParsed) {
+            if (dataParsed.r == "scenes") { return; }
+            if (dataParsed.r == "groups") {
+               var groupid = dataParsed.id;
+               var state = dataParsed.state
+               for (var group in this.groups) {
+                   if ( group[groupid] && group[groupid] == groupid ) {
+                       this.groups[groupid].state = state;
+                       return;
+                   }
+               }
+            }
             for (var nodeId in this.devices) {
                 var item = this.devices[nodeId];
 


### PR DESCRIPTION
This is useful for the get node with groups. Now the group state is instantly updated when called for.  This used be updated by the 15 second refresh interval. 