### PR TITLE
Fix crash in nodes/in.js when state is null

### DIFF
--- a/nodes/in.js
+++ b/nodes/in.js
@@ -83,10 +83,11 @@ module.exports = function(RED) {
                         text: "node-red-contrib-deconz/in:status.not_reachable"
                     });
                 } else {
+                    var nodeState = (node.config.state in device.state) ? (device.state[node.config.state]) : null;
                     node.status({
                         fill: "green",
                         shape: "dot",
-                        text: (node.config.state in device.state) ? (device.state[node.config.state]).toString() : "node-red-contrib-deconz/in:status.connected"
+                        text: nodeState !== null ? nodeState.toString() : "node-red-contrib-deconz/in:status.connected"
                     });
                 }
                 if (node.oldState === undefined && device.state[node.config.state]) { node.oldState = device.state[node.config.state]; }


### PR DESCRIPTION
Ran into this crash. This seems to fix the issue.

> Node-RED[361]: 15 Oct 21:38:58 - [red] Uncaught Exception:
> Node-RED[361]: 15 Oct 21:38:58 - TypeError: Cannot read property 'toString' of null
> Node-RED[361]:     at deConzItemIn.getState (/var/nodered/node_modules/node-red-contrib-deconz/nodes/in.js:89:103)
> Node-RED[361]:     at Timeout._onTimeout (/var/nodered/node_modules/node-red-contrib-deconz/nodes/in.js:44:34)
> Node-RED[361]:     at ontimeout (timers.js:482:11)
> Node-RED[361]:     at tryOnTimeout (timers.js:317:5)
> Node-RED[361]:     at Timer.listOnTimeout (timers.js:277:5)