### PR TITLE
Added the option to use scenes

### DIFF
--- a/nodes/out.html
+++ b/nodes/out.html
@@ -106,7 +106,8 @@
                       'xy',
                       'alert',
                       'effect',
-                      'colorloopspeed'
+                      'colorloopspeed',
+                      'scene' // added scene
                 ]
             };
             $('#node-input-command').typedInput({


### PR DESCRIPTION
I made a few adjustments to @andreypopov files (out.html and out.js) to be able to send scenes, works perfect for me (Philips HUE and GLEDOPTO controller).

It is of course not as clean and nice as all the other stuff but it works. Something that would be nice is if it checked which scene ID would be valid. Because now you can add whatever ID you want and I don't know what will happen if you use a not existing one... Probably nothing but still...

What I did:
out.html:
Line 110: added scene as an option

out.js:
Line 111: added scene as an option, parse payload as Int.
Line 146 - 149: added extra IF statement to be able to create the right URL for recalling scenes
Line 158: changed if-else statement to make sure no post data is set.

All the love and thanks to @andreypopov he made it possible!

p.s. to make it work:

1.     Edit those files in the .node-red/node_modules/node-red-contrib-deconz/nodes folder
2.     Restart node-red
3.     Make a out node and select command "scene"
4.     select "number" as payload and then the ID of the scene (easy to find with HUE essentials or something, normally the fist scene you created = 1, second 2, etc.)
